### PR TITLE
load google-fonts with https

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,7 +21,7 @@
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
 
 <!-- Google fonts -->
-<link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic&subset=latin-ext">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic&subset=latin-ext">
 
 {% if site.paginate %}
 <!-- font Awesome -->


### PR DESCRIPTION
## bug
Chromeで、httpsのサイトからhttpのリソースを読み込んでいるよという警告が表示されていました。

許可するまでgoogle web fontがロードされないので、論文タイトル部分の見た目が崩れています。

![](https://gyazo.com/591946c805125d331f0c2092fc2c6055/raw)

エラーコンソールの3つのうち中央はブラウザ拡張の物なので関係ないです。1つ目と3つ目のmixed content errorが問題のやつです

## fix
httpsから読むようにしました。

このすぐ下のfont-awesomeはprotocol省略でロードしているので、そっちに合わせるべきか迷っている

